### PR TITLE
Update ssh command for windows

### DIFF
--- a/deploy-apps/ssh-services.html.md.erb
+++ b/deploy-apps/ssh-services.html.md.erb
@@ -70,7 +70,7 @@ To establish direct command-line access to your service instance, use the releva
 
 <pre class="terminal">$ mysql -u b5136e448be920 -h 0 -p -D ad_b2fca6t49704585d -P 63306</pre>
   * Replace `b5136e448be920` with the username provided under `username` in your service key.
-  * `-h 0` instructs `mysql` to connect to your local machine.
+  * `-h 0` instructs `mysql` to connect to your local machine (use '-h 127.0.0.1' for Windows Operating System).
   * `-p` instructs `mysql` to prompt for a password. When prompted, use the password provided under `password` in your service key.
   * Replace `ad_b2fca6t49704585d` with the database name provided under `name` in your service key.
   * `-P 63306` instructs `mysql` to connect on port `63306`.


### PR DESCRIPTION
Command "mysql -u *** -h 0 *****" does not work for windows, need to replace 0 with "127.0.0.1"
Following error are throw: ERROR 2005 (HY000): Unknown MySQL server host '0' (0)